### PR TITLE
let fire'd event be cancelable

### DIFF
--- a/src/instance/utils.js
+++ b/src/instance/utils.js
@@ -33,16 +33,18 @@
       * @param {string} type An event name.
       * @param detail
       * @param {Node} toNode Target node.
+      * @returns {boolean} False if event's cancelable and prevendDefault()
+      * was invoked, true otherwise.
       */
-    fire: function(type, detail, toNode, bubbles) {
+    fire: function(type, detail, toNode, bubbles, cancelable) {
       var node = toNode || this;
       //log.events && console.log('[%s]: sending [%s]', node.localName, inType);
-      node.dispatchEvent(
+      return node.dispatchEvent(
         new CustomEvent(type, {
           bubbles: (bubbles !== undefined ? bubbles : true), 
+          cancelable: (cancelable !== undefined) ? cancelable : true,
           detail: detail
         }));
-      return detail;
     },
     /**
       * Fire an event asynchronously.


### PR DESCRIPTION
Currently, fire is non-cancelable CustomEvent, and return only the details.

In this case, the fire can only be used to inform some events, and cannot do other thing.
// However, we can use detail, but it's not part of dom event.

Compares to YUI's fire, which returns something similar to the original method of dispatchEvent.
So I think its necessary to return the value of dispatchEvent.
