### PR TITLE
fix special attribute name on IE.

### DIFF
--- a/src/declaration/attributes.js
+++ b/src/declaration/attributes.js
@@ -32,8 +32,18 @@
           // remove excess ws
           n = names[i].trim();
           // do not override explicit entries
-          if (n && publish[n] === undefined && base[n] === undefined) {
-            publish[n] = null;
+          if (n && publish[n] === undefined) {
+            try {
+              if (base[n] === undefined) {
+                publish[n] = null;
+              }
+            } catch (e) {
+              // IE will produce an TypeError for some attributes
+              if (e.name == "TypeError") {
+                publish[n] = null;
+                console.warn("attribute name [" + n + "] is not recommended");
+              }
+            }
           }
         }
       }

--- a/src/declaration/properties.js
+++ b/src/declaration/properties.js
@@ -68,8 +68,18 @@
     requireProperties: function(properties, prototype, base) {
       // ensure a prototype value for each property
       for (var n in properties) {
-        if (prototype[n] === undefined && base[n] === undefined) {
-          prototype[n] = properties[n];
+        if (prototype[n] === undefined) {
+          try {
+            if (base[n] === undefined) {
+              prototype[n] = properties[n];
+            }
+          } catch (e) {
+            // IE will produce an TypeError for some attributes
+            if (e.name == "TypeError") {
+              prototype[n] = properties[n];
+              console.warn("attribute name [" + n + "] is not recommended");
+            }
+          }
         }
       }
     },


### PR DESCRIPTION
This patch should fix https://github.com/Polymer/polymer/issues/332
and https://github.com/Polymer/polymer/issues/372

The list of pissible wrong attributes can be retrieved by following codes: 

```
    var blacklist = [];
    Object.keys(HTMLElement.prototype).forEach(function (item) {
        try {
            HTMLElement.prototype[item];
        } catch (e) {
            console.log(item + ": " + e.name + ", " + e.message);
            blacklist.push(item);
        }
    });
    blacklist.sort();
    document.write("<h3>blacklist</h3>" + blacklist.join("<br/>"));
```

Here is a single web page http://jsbin.com/gofay/1
