### PR TITLE
Support for {{binding.events.via.a.path}}

### DIFF
--- a/src/instance/events.js
+++ b/src/instance/events.js
@@ -34,12 +34,23 @@
     },
     // call 'method' or function method on 'obj' with 'args', if the method exists
     dispatchMethod: function(obj, method, args) {
-      if (obj) {
-        log.events && console.group('[%s] dispatch [%s]', obj.localName, method);
-        var fn = typeof method === 'function' ? method : obj[method];
-        if (fn) {
-          fn[args ? 'apply' : 'call'](obj, args);
+      if (!obj) return;
+      log.events && console.group('[%s] dispatch [%s]', obj.localName, method);
+      try {
+        if (typeof method === 'string') {
+          var parts = method.split('.');
+          for (var i = 0; i < parts.length - 1; i++) {
+            obj = obj[parts[i]];
+          }
+          method = obj[parts[parts.length - 1]];
         }
+
+        if (method) {
+          method[args ? 'apply' : 'call'](obj, args);
+        } else {
+          log.events && console.warn('Unable to resolve method');
+        }
+      } finally {
         log.events && console.groupEnd();
         Platform.flush();
       }

--- a/test/html/event-handlers-bound-path.html
+++ b/test/html/event-handlers-bound-path.html
@@ -1,0 +1,48 @@
+<!doctype html>
+<!--
+Copyright (c) 2014 The Polymer Project Authors. All rights reserved.
+This code may only be used under the BSD style license found at http://polymer.github.io/LICENSE.txt
+The complete set of authors may be found at http://polymer.github.io/AUTHORS.txt
+The complete set of contributors may be found at http://polymer.github.io/CONTRIBUTORS.txt
+Code distributed by Google as part of the polymer project is also
+subject to an additional IP rights grant found at http://polymer.github.io/PATENTS.txt
+-->
+<html>
+  <head>
+    <title>event handlers</title>
+    <script src="../../../platform/platform.js"></script>
+    <link rel="import" href="../../polymer.html">
+    <script src="../../../tools/test/htmltest.js"></script>
+    <script src="../../../tools/test/chai/chai.js"></script>
+  </head>
+  <body>
+
+  <x-test></x-test>
+
+  <polymer-element name="x-test-receiver">
+    <script>
+      Polymer('x-test-receiver', {
+        doThings: function(e) {
+          e.thingsDone = true;
+        }
+      });
+    </script>
+  </polymer-element>
+
+  <polymer-element name="x-test">
+    <template>
+      <x-test-receiver id="receiver"></x-test-receiver>
+      <button id="button" on-tap="{{$.receiver.doThings}}"></button>
+    </template>
+    <script>
+      Polymer('x-test', {
+        ready: function() {
+          var e = this.fire('tap', {}, this.$.button);
+          chai.assert.isTrue(e.thingsDone, 'events can be bound to object paths');
+          done();
+        }
+      });
+    </script>
+  </polymer-element>
+  </body>
+</html>

--- a/test/js/events.js
+++ b/test/js/events.js
@@ -50,6 +50,7 @@ suite('events', function() {
 
 htmlSuite('events-declarative', function() {
   htmlTest('html/event-handlers.html');
+  htmlTest('html/event-handlers-bound-path.html');
   htmlTest('html/event-handlers-host.html');
   htmlTest('html/event-handlers-light.html');
   htmlTest('html/event-path.html');


### PR DESCRIPTION
Primarily, this allows for JS-less event wireup, such as:

``` html
<polymer-element name="x-foo">
  <template>
    <core-overlay id="overlay"></core-overlay>
    <button id="button" on-tap="{{$.overlay.toggle}}"></button>
  </template>
</polymer-element>
```

Also, I snuck in a warning (when logging is on) to help diagnose when method dispatch fails to resolve
