### PR TITLE
object attributes shouldn't be regards as mustache

### DIFF
--- a/src/instance/attributes.js
+++ b/src/instance/attributes.js
@@ -37,14 +37,14 @@
       // all lower-case, so this is case-insensitive search)
       var name = this.propertyForAttribute(name);
       if (name) {
+        // get original value
+        var currentValue = this[name];
         // filter out 'mustached' values, these are to be
         // replaced with bound-data and are not yet values
         // themselves
-        if (value && value.search(scope.bindPattern) >= 0) {
+        if (currentValue !== Object(currentValue) && value && value.search(scope.bindPattern) >= 0) {
           return;
         }
-        // get original value
-        var currentValue = this[name];
         // deserialize Boolean or Number values from attribute
         var value = this.deserializeValue(value, currentValue);
         // only act if the value has changed

--- a/test/html/take-attributes.html
+++ b/test/html/take-attributes.html
@@ -106,6 +106,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
     <x-obj id="obj1" values='{ "name": "Brandon", "nums": [1, 22, 33] }'></x-obj>
     <x-obj id="obj2" values='{ "color": "Red" }'></x-obj>
     <x-obj id="obj3" values="{ 'movie': 'Buckaroo Banzai', 'DOB': '07/31/1978' }"></x-obj>
+    <x-obj id="obj4" values='{ "pattern": "{{}}" }'></x-obj>
 
     <polymer-element name="x-commas" attributes="bool,num,str">
       <script>
@@ -199,6 +200,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
         assert.deepEqual(document.querySelector("#obj1").values, { name: 'Brandon', nums: [1, 22, 33] });
         assert.deepEqual(document.querySelector("#obj2").values, { "color": "Red" });
         assert.deepEqual(document.querySelector("#obj3").values, { movie: 'Buckaroo Banzai', DOB: '07/31/1978' });
+        assert.deepEqual(document.querySelector("#obj4").values, { pattern: '{{}}' });
         //
         // Comma test
         assert.isTrue(document.querySelector('#comma1').bool);


### PR DESCRIPTION
Currently, the attributes is checked for mustache. If it's mustached, then the deserialize won't work.
However, in my opionion, if the attribute is object, then it may contains any thing, it should be deserialized anyway.
