### PR TITLE
Check if inferredType is `undefined` in deserialize.js:64

### DIFF
--- a/src/lib/deserialize.js
+++ b/src/lib/deserialize.js
@@ -61,7 +61,7 @@
       inferredType = 'date';
     }
     // delegate deserialization via type string
-    return typeHandlers[inferredType](value, currentValue);
+    return inferredType !== 'undefined'?typeHandlers[inferredType](value, currentValue):undefined;
   }
 
   // exports


### PR DESCRIPTION
Error discovered in Firefox 30.0 on Ubuntu 14.04
