### PR TITLE
Cache window.ShadowDOMPolyfill value in closures

### DIFF
--- a/src/declaration/prototype.js
+++ b/src/declaration/prototype.js
@@ -15,6 +15,8 @@
   var isBase = scope.isBase;
   var extend = scope.extend;
 
+  var hasShadowDOMPolyfill = window.ShadowDOMPolyfill;
+
   // prototype api
 
   var prototype = {
@@ -101,7 +103,7 @@
       // this.$.image.src = this.resolvePath('images/foo.png')
       this.addResolvePathApi();
       // under ShadowDOMPolyfill, transforms to approximate missing CSS features
-      if (window.ShadowDOMPolyfill) {
+      if (hasShadowDOMPolyfill) {
         Platform.ShadowCSS.shimStyling(this.templateContent(), name, extendee);
       }
       // allow custom element access to the declarative context

--- a/src/declaration/styles.js
+++ b/src/declaration/styles.js
@@ -15,6 +15,8 @@
   var api = scope.api.instance.styles;
   var STYLE_SCOPE_ATTRIBUTE = api.STYLE_SCOPE_ATTRIBUTE;
 
+  var hasShadowDOMPolyfill = window.ShadowDOMPolyfill;
+
   // magic words
 
   var STYLE_SELECTOR = 'style';
@@ -187,7 +189,7 @@
       if (scope === document) {
         scope = document.head;
       }
-      if (window.ShadowDOMPolyfill) {
+      if (hasShadowDOMPolyfill) {
         scope = document.head;
       }
       // TODO(sorvell): necessary for IE

--- a/src/instance/styles.js
+++ b/src/instance/styles.js
@@ -12,7 +12,8 @@
   // imports
 
   var log = window.logFlags || {};
-  
+  var hasShadowDOMPolyfill = window.ShadowDOMPolyfill;
+
   // magic words
   
   var STYLE_SCOPE_ATTRIBUTE = 'element';
@@ -60,7 +61,7 @@
       if (!scope) {
         return;
       }
-      if (window.ShadowDOMPolyfill) {
+      if (hasShadowDOMPolyfill) {
         cssText = shimCssText(cssText, scope.host);
       }
       var style = this.element.cssTextToScopeStyle(cssText,
@@ -82,7 +83,7 @@
       return cache[name];
     },
     styleCacheForScope: function(scope) {
-      if (window.ShadowDOMPolyfill) {
+      if (hasShadowDOMPolyfill) {
         var scopeName = scope.host ? scope.host.localName : scope.localName;
         return polyfillScopeStyleCache[scopeName] || (polyfillScopeStyleCache[scopeName] = {});
       } else {


### PR DESCRIPTION
This avoids unnecessary references properties on window, which are
slow to look up.

Noticed this when looking at a CPU profile of the code review tool.
