### PR TITLE
change layout.html to layout.css

### DIFF
--- a/layout.css
+++ b/layout.css
@@ -1,12 +1,12 @@
-<!--
+/*
 Copyright (c) 2014 The Polymer Project Authors. All rights reserved.
 This code may only be used under the BSD style license found at http://polymer.github.io/LICENSE.txt
 The complete set of authors may be found at http://polymer.github.io/AUTHORS.txt
 The complete set of contributors may be found at http://polymer.github.io/CONTRIBUTORS.txt
 Code distributed by Google as part of the polymer project is also
 subject to an additional IP rights grant found at http://polymer.github.io/PATENTS.txt
--->
-<style shim-shadowdom>
+*/
+
 /*******************************
           Flex Layout
 *******************************/
@@ -274,5 +274,3 @@ html /deep/ [segment], html /deep/ segment {
   box-shadow: 0px 0px 0px 1px rgba(0, 0, 0, 0.1);
   border-radius: 5px 5px 5px 5px;
 }
-
-</style>

--- a/polymer.html
+++ b/polymer.html
@@ -5,7 +5,7 @@
 -->
 <link rel="import" href="../polymer-gestures/polymer-gestures.html">
 <link rel="import" href="../polymer-expressions/polymer-expressions.html">
-<link rel="import" href="layout.html">
+<link rel="stylesheet" href="layout.css" shim-shadowdom>
 <script src="src/polymer.js"></script>
 <script src="src/boot.js"></script>
 


### PR DESCRIPTION
I don't know if there is a reason this was an html import before, but it seems like it should just be a stylesheet. I did some quick testing and the shim-shadowdom attribute seems to work on a link tag as well, and the vulcanizer will retain it when inlined.
