### PR TITLE
Fix stylesheet without href

### DIFF
--- a/src/declaration/styles.js
+++ b/src/declaration/styles.js
@@ -21,7 +21,7 @@
 
   var STYLE_SELECTOR = 'style';
   var STYLE_LOADABLE_MATCH = '@import';
-  var SHEET_SELECTOR = 'link[rel=stylesheet]';
+  var SHEET_SELECTOR = 'link[rel=stylesheet][href]';
   var STYLE_GLOBAL_SCOPE = 'global';
   var SCOPE_ATTR = 'polymer-scope';
 


### PR DESCRIPTION
If a `<link rel="stylesheet">` without an `href` attribute is present, it should be ignored, whereas currently an HTTP request is sent to `http://xxx/null`.
