### PR TITLE
Fix grunfile.js

### DIFF
--- a/gruntfile.js
+++ b/gruntfile.js
@@ -111,7 +111,7 @@ module.exports = function(grunt) {
 
 
   grunt.registerTask('default', ['minify']);
-  grunt.registerTask('minify', ['concat_sourcemap', 'version', 'string-replace', 'uglify']);
+  grunt.registerTask('minify', ['version', 'string-replace', 'concat_sourcemap', 'uglify']);
   grunt.registerTask('test', ['override-chrome-launcher', 'karma:polymer']);
   grunt.registerTask('test-build', ['minify', 'stash', 'test', 'restore']);
   grunt.registerTask('test-buildbot', ['override-chrome-launcher', 'karma:buildbot', 'minify', 'stash', 'karma:buildbot', 'restore']);


### PR DESCRIPTION
Version was not properly being injected before. Currently that is serving as the initial declaration of Polymer if you are running platform-less. For instance the current master branch is broken if you are running without platform.js because of this. It looks like the 0.4.0 release tag does have the version (so it works), but I am not sure how it was added?
