### PR TITLE
Update dev dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,20 +3,20 @@
   "version": "0.4.1",
   "devDependencies": {
     "chai": "^1.9.1",
-    "grunt": "^0.4",
+    "grunt": "^0.4.5",
     "grunt-audit": "^0.0.3",
-    "grunt-concat-sourcemap": "^0.4.1",
-    "grunt-contrib-concat": "^0.4.0",
-    "grunt-contrib-uglify": "^0.5.0",
-    "grunt-karma": "^0.8.2",
-    "grunt-string-replace": "^0.2.7",
-    "karma": "^0.12.14",
+    "grunt-concat-sourcemap": "^0.4.3",
+    "grunt-contrib-concat": "^0.5.0",
+    "grunt-contrib-uglify": "^0.6.0",
+    "grunt-karma": "^0.9.0",
+    "grunt-string-replace": "^1.0.0",
+    "karma": "^0.12.23",
     "karma-crbot-reporter": "^0.0.4",
-    "karma-firefox-launcher": "^0.1.0",
-    "karma-ie-launcher": "^0.1.0",
-    "karma-mocha": "^0.1.3",
-    "karma-safari-launcher": "^0.1.0",
+    "karma-firefox-launcher": "^0.1.3",
+    "karma-ie-launcher": "^0.1.5",
+    "karma-mocha": "^0.1.9",
+    "karma-safari-launcher": "^0.1.1",
     "karma-script-launcher": "^0.1.0",
-    "mocha": "^1.18.0"
+    "mocha": "^1.21.4"
   }
 }


### PR DESCRIPTION
We have a few outdated dev dependencies in master atm. Specifically:

grunt-karma (package: ^0.8.2, latest: 0.9.0)
grunt-concat-sourcemap (package: ^0.4.1, latest: 0.4.3)
grunt-string-replace (package: ^0.2.7, latest: 1.0.0)
karma-ie-launcher (package: ^0.1.0, latest: 0.1.5)
karma-firefox-launcher (package: ^0.1.0, latest: 0.1.3)
karma-mocha (package: ^0.1.3, latest: 0.1.9)
grunt-contrib-uglify (package: ^0.5.0, latest: 0.6.0)
karma-safari-launcher (package: ^0.1.0, latest: 0.1.1)
grunt-contrib-concat (package: ^0.4.0, latest: 0.5.0)
karma (package: ^0.12.14, latest: 0.12.23)

This PR updates us to the latest versions of these packages.
