### PR TITLE
Polymer properties with names the same as DOM accessors will now work correctly

### DIFF
--- a/src/declaration/properties.js
+++ b/src/declaration/properties.js
@@ -134,7 +134,9 @@
 
       var privateName = name + '_';
       var privateObservable  = name + 'Observable_';
-      proto[privateName] = proto[name];
+      var originalProp = Object.getOwnPropertyDescriptor(proto, name);
+      if (originalProp)
+        Object.defineProperty(proto, privateName, originalProp);
 
       Object.defineProperty(proto, name, {
         get: function() {

--- a/test/js/attrs.js
+++ b/test/js/attrs.js
@@ -13,3 +13,31 @@ htmlSuite('attributes-declarative', function() {
   htmlTest('html/attr-mustache.html');
   htmlTest('html/prop-attr-reflection.html');
 });
+
+suite('attributes', function() {
+  var assert = chai.assert;
+
+  test('override dom accessor', function() {
+    var p = document.createElement('polymer-element');
+    p.setAttribute('name', 'test-override-dom-accessor');
+    p.setAttribute('attributes', 'title');
+    p.setAttribute('noscript', '');
+    p.init();
+
+    // Chrome's accessors are busted:
+    // https://code.google.com/p/chromium/issues/detail?id=43394
+    // 
+    // Safari is similar but ShadowDOMPolyfill fixes the problem for us:
+    // https://bugs.webkit.org/show_bug.cgi?id=49739
+    // https://github.com/Polymer/ShadowDOM/blob/3c9068695f179d3c4d5c4eab037a904a8e6efaae/src/wrappers.js#L181
+    // 
+    // So for this test we only need to worry about Chrome's breakage.
+    var isBrokenChrome = !Object.getOwnPropertyDescriptor(HTMLElement.prototype,
+        'title');
+
+    var t = document.createElement('test-override-dom-accessor');
+    t.title = 123;
+
+    assert.strictEqual(t.title, isBrokenChrome ? '123' : 123);
+  });
+});


### PR DESCRIPTION
This fixes https://github.com/Polymer/platform/issues/88

The old behavior happened to work on Chrome because Chrome is broken, and conversely failed on all of the correct browsers. Ironic. The new test adds links to the relevant bugs. (If only these bugs didn't take 4+ years to fix. Sigh.)

Thanks to @arv for the suggested fix!
