### PR TITLE
Remove replacing apostrophes with double apostrophes before trying to parse string to JSON

### DIFF
--- a/src/lib/deserialize.js
+++ b/src/lib/deserialize.js
@@ -41,10 +41,7 @@
         return value;
       }
       try {
-        // If the string is an object, we can parse is with the JSON library.
-        // include convenience replace for single-quotes. If the author omits
-        // quotes altogether, parse will fail.
-        return JSON.parse(value.replace(/'/g, '"'));
+        return JSON.parse(value);
       } catch(e) {
         // The object isn't valid JSON, return the raw value
         return value;


### PR DESCRIPTION
For example let's have JSON

{"test" : "it's perfectly valid JSON"}

And then you plug this JSON to your element's published property attribute, the parsing will fail due to replace which is being done right now.

I think it's reasonable to remove this replace and allow only valid (http://json.org/) JSON to be parsed.

By the way if you realize what are the implications of this replacing you'll find the comment saying: " // include convenience replace for single-quotes. If the author omits" very funny.
